### PR TITLE
Hardcode DOS_EPOCH

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
@@ -42,7 +42,7 @@ import static org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.E
 
 public class CompileEnvironmentUtil {
 
-    public static long DOS_EPOCH = new GregorianCalendar(1980, Calendar.JANUARY, 1, 0, 0, 0).getTimeInMillis();
+    public static long DOS_EPOCH = 315532800000L; // 1980-01-01T00:00:00Z
 
     @NotNull
     public static ModuleChunk loadModuleChunk(File buildFile, MessageCollector messageCollector) {


### PR DESCRIPTION
This use of GregorianCalendar was semi-deterministic because it didn't specify the timezone or locale. The value can change based on the user's system settings.

Additionally, instantiating a Calendar is relatively expensive, because a bunch of locale-specific data may be parsed. This is insignificant for a single execution, but can add up in something like a distributed build system.

Hardcoding the exact value solves both of these problems.